### PR TITLE
このサイトの言語を日本語に設定

### DIFF
--- a/page/.vuepress/config.js
+++ b/page/.vuepress/config.js
@@ -89,5 +89,10 @@ module.exports = {
         "sitemap": {
             hostname: "https://" + domain
         }
+    },
+    locales: {
+        "/": {
+            lang: "ja_JP"
+        }
     }
 }


### PR DESCRIPTION
確認してみたところ、`<html lang="en_US">`と書いてあったので`<html
lang="ja_JP">`に変えた。（どうして今まで気づかなかったんだろう？）