### PR TITLE
ツイッターのシェアボタンが正しく機能しない問題を改善

### DIFF
--- a/page/.vuepress/theme/components/Page.vue
+++ b/page/.vuepress/theme/components/Page.vue
@@ -4,7 +4,7 @@
 
     <Content class="theme-default-content"/>
 
-    <ShareButton />
+    <ShareButton :key="$page" />
 
     <AuthorInfo />
 


### PR DESCRIPTION
「ツイート」をクリックしたときに共有されるURLが間違っている場合があったので、ツイートボタンを別のページに移動するたびに再レンダリングすることで改善