### PR TITLE
viewportの設定

### DIFF
--- a/page/.vuepress/config.js
+++ b/page/.vuepress/config.js
@@ -76,7 +76,14 @@ module.exports = {
     },
     head: [
         ...google_analytics(),
-        ...google_adsense()
+        ...google_adsense(),
+        ["meta", {
+            charset: "utf-8"
+        }],
+        ["meta", {
+            name: "viewport",
+            content: "width=device-width,initial-scale=1"
+        }]
     ],
     plugins: {
         "seo": {


### PR DESCRIPTION
vuepressのバグでモバイル版firefoxでデスクトップ版のページが表示されてしまうバグがあったので回避するやつ。
vuepressはつぎのvuepress2に向けて作業中らしく多分このバグはしばらく修正されそうにない。
新しく出るvuepress2では改善されているらしい。